### PR TITLE
チェックボックスのコンポーネント構造を改善

### DIFF
--- a/src/components/CheckBox.tsx
+++ b/src/components/CheckBox.tsx
@@ -23,10 +23,10 @@ const CustomCheckbox = styled.input.attrs({ type: 'checkbox' })`
 interface Props {
   setSelectedPrefectures: React.Dispatch<React.SetStateAction<number[]>>;
   selectedPrefectures: number[];
-  prefectures: Prefecture[];
+  pref: Prefecture;
 }
 
-const PrefectureCheck:React.FC<Props> = ({selectedPrefectures,prefectures,setSelectedPrefectures}) => {
+const CheckBox:React.FC<Props> = ({selectedPrefectures,pref,setSelectedPrefectures}) => {
 
     //都道府県のチェックボックスの選択状態が変更されたときに実行される関数
     const handleCheckboxChange = (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -40,7 +40,7 @@ const PrefectureCheck:React.FC<Props> = ({selectedPrefectures,prefectures,setSel
 
   return (
     <>
-      {prefectures.map((pref) => (
+
         <div key={pref.prefCode}>
           <CustomLabel>
             <CustomCheckbox
@@ -52,9 +52,9 @@ const PrefectureCheck:React.FC<Props> = ({selectedPrefectures,prefectures,setSel
             {pref.prefName}
           </CustomLabel>
         </div>
-      ))}
+  
     </>
   )
 };
 
-export default PrefectureCheck;
+export default CheckBox;

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,11 +1,11 @@
 import React, { useEffect, useState } from 'react';
 import styled from 'styled-components';
-import { getChildPopulation, getElderlyPopulation, getPopulation, getPrefectures, getWorkingPopulation } from './api/resas';
+import {  getPrefectures} from './api/resas';
 import { Population, Prefecture } from '@/interfaces';
-import PrefectureCheck from '@/components/PrefectureCheck';
 import Graph from '@/components/Graph';
 import { fetchAllPopulationData } from '@/lib/fetchPopulation';
 import { GetStaticProps } from 'next';
+import CheckBox from '@/components/Checkbox';
 
 const Container = styled.div`
   display: flex;
@@ -36,7 +36,6 @@ const CheckboxContainer = styled.div`
     grid-template-columns: repeat(5, 1fr);
   }
 `;
-
 
 
 const Tab = styled.a`
@@ -81,15 +80,12 @@ export const getStaticProps: GetStaticProps = async () => {
   }
 };
 
-
 const IndexPage: React.FC<HomeProps> = ({prefectures}) => {
 
   const [selectedPrefectures, setSelectedPrefectures] = useState<number[]>([]); //選択された都道府県コードの一覧
   const [population, setPopulation] = useState<Population[]>([]); 
   const [loading,setLoading] = useState<boolean>(true); //ローディング状態管理
   const [selectedDisplayData,setSelectedDisplayData] = useState<number>(0); //表示するデータの配列 0:総人口、2:年少人口、3:生産年齢人口、4:老年人口
-
-    
 
   //選択された都道府県が変更されたときに実行
   useEffect(() => {
@@ -112,7 +108,6 @@ const IndexPage: React.FC<HomeProps> = ({prefectures}) => {
 
   }, [selectedPrefectures, selectedDisplayData]);
 
-
   return (
     <Container>
       <div>
@@ -124,14 +119,15 @@ const IndexPage: React.FC<HomeProps> = ({prefectures}) => {
         </Tabs>
         <MainContainer>
             <CheckboxContainer>
-              <PrefectureCheck prefectures={prefectures} selectedPrefectures={selectedPrefectures} setSelectedPrefectures={setSelectedPrefectures} />
+              {prefectures.map((pref) => (
+                  <CheckBox key={pref.prefCode} pref={pref} selectedPrefectures ={selectedPrefectures} setSelectedPrefectures ={setSelectedPrefectures}/>
+                ))}
             </CheckboxContainer>
             <Graph prefectures={prefectures} selectedPrefectures = {selectedPrefectures} selectedDisplayData={selectedDisplayData} population={population} loading={loading} />
         </MainContainer>
       </div>
     </Container>
   )
-
 }
 
 export default IndexPage;


### PR DESCRIPTION
## 実装内容

チェックボックス一つをコンポーネント化し都道府県のデータをそれぞれチェックボックスコンポーネントに受け渡す仕組みに変更。

この変更により、コンポーネントは都道府県一つのみのデータを受け取り保持するようになり、可読性や保守性が向上した