### PR TITLE
ResponsiveContainerが原因のテストでのエラーを解決

### DIFF
--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -1,1 +1,11 @@
 import '@testing-library/jest-dom';
+
+class MockResizeObserver {
+    observe = jest.fn();
+    unobserve = jest.fn();
+    disconnect = jest.fn();
+}
+
+beforeEach(() => {
+    window.ResizeObserver = MockResizeObserver as any;
+});


### PR DESCRIPTION
## 修正内容

UI修正後、テストを実行したら通らなくなったので修正

### エラー内容

エラー文　「TypeError: window.ResizeObserver is not a constructor」

window.ResizeObserverがテスト環境で利用できないというエラー

### 原因と解決策

rechartsライブラリの<ResponsiveContainer>がその内部でResizeObserverを使用している可能性があると考え、 setupTest.tsでResizeObserverのモックを作成して解決。
