### PR TITLE
都道府県の取得をgetServerSidePropsに変更

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -4,7 +4,7 @@ import {  getPrefectures} from './api/resas';
 import { Population, Prefecture } from '@/interfaces';
 import Graph from '@/components/Graph';
 import { fetchAllPopulationData } from '@/lib/fetchPopulation';
-import { GetStaticProps } from 'next';
+import { GetServerSideProps} from 'next';
 import CheckBox from '@/components/CheckBox';
 
 const Container = styled.div`
@@ -95,9 +95,9 @@ interface HomeProps {
 }
 
 //都道府県の一覧を取得
-export const getStaticProps: GetStaticProps = async () => {
+export const getServerSideProps: GetServerSideProps = async () => {
   try {
-    const prefectures:Prefecture = await getPrefectures();
+    const prefectures: Prefecture = await getPrefectures();
     if (!prefectures) {
       console.error('getPrefectures returned undefined');
       return { props: { prefectures: [] } };


### PR DESCRIPTION
## 変更内容

### 都道府県一覧をAPIから取得する際にgetStaticPropsを使用していたがgetServerSidepropsで取得する方法に変更。

### 理由

都道府県一覧は基本的に更新されることはなく、頻繁に取得する必要がないと考えgetStaticPropsを使用していたが、この場合再ビルドしない限りユーザのアクションなどによっては更新されることはなく、「都道府県一覧のチェックボックスを動的に生成する」という要件を満たしていないのではないかと思い変更。

### 備考

useEffectを使い、クライアントサイドで初回マウント時にのみ取得する方法でも良い
